### PR TITLE
Adapt OpenShift Pipelines to 1.17

### DIFF
--- a/ai-examples/charts/onboard-datascience/templates/pipelines/kfp-run-pipelines-pipeline.yaml
+++ b/ai-examples/charts/onboard-datascience/templates/pipelines/kfp-run-pipelines-pipeline.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: pipeline-run-{{ .Values.pipeline.name }}

--- a/ai-examples/charts/onboard-datascience/templates/pipelines/kfp-run-pipelines-task.yaml
+++ b/ai-examples/charts/onboard-datascience/templates/pipelines/kfp-run-pipelines-task.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/ai-examples/charts/onboard-datascience/templates/pipelines/kfp-upload-pipeline.yaml
+++ b/ai-examples/charts/onboard-datascience/templates/pipelines/kfp-upload-pipeline.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.pipeline.enabled }}
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: pipeline-upload-{{ .Values.pipeline.name }}
@@ -24,17 +24,21 @@ spec:
   tasks:
     - name: fetch-repository
       params:
-        - name: url
+        - name: URL
           value: $(params.GIT_REPO)
-        - name: revision
+        - name: REVISION
           value: $(params.GIT_REVISION)
-        - name: deleteExisting
+        - name: DELETE_EXISTING
           value: 'true'
-        - name: sslVerify
+        - name: SSL_VERIFY
           value: $(params.GIT_SSL_VERIFY)
       taskRef:
-        kind: ClusterTask
-        name: git-clone
+        params:
+          - name: name
+            value: git-clone
+          - name: namespace
+            value: openshift-pipelines
+        resolver: cluster
       workspaces:
         - name: output
           workspace: workspace-source

--- a/ai-examples/charts/onboard-datascience/templates/pipelines/kfp-upload-task.yaml
+++ b/ai-examples/charts/onboard-datascience/templates/pipelines/kfp-upload-task.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.pipeline.enabled }}
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:


### PR DESCRIPTION
- Migrate Pipelines and Tasks to stable API v1.
- Migrate from ClusterTask to ClusterResolver as they were removed in OCP-Pipelines 1.17.